### PR TITLE
:technologist: [fixed_string] improve readability in compilation errors

### DIFF
--- a/reflect
+++ b/reflect
@@ -139,13 +139,16 @@ struct member_name_info {
 
 template<class T, std::size_t Size>
 struct fixed_string {
-  constexpr explicit(false) fixed_string(const T* str) { for (decltype(Size) i{}; i < Size; ++i) { data[i] = str[i]; } }
+  constexpr explicit(false) fixed_string(const T* str) {
+    for (decltype(Size) i{}; i < Size; ++i) { data[i] = str[i]; }
+    data[Size] = T();
+  }
   [[nodiscard]] constexpr auto operator<=>(const fixed_string&) const = default;
   [[nodiscard]] constexpr explicit(false) operator std::string_view() const { return {std::data(data), Size}; }
   [[nodiscard]] constexpr auto size() const { return Size; }
-  std::array<T, Size> data{};
+  T data[Size+1];
 };
-template<class T, std::size_t Size> fixed_string(const T (&str)[Size]) -> fixed_string<T, Size-1>;
+template<class T, std::size_t Capacity, std::size_t Size = Capacity-1> fixed_string(const T (&str)[Capacity]) -> fixed_string<T, Size>;
 
 namespace detail {
 template<class T, class... Ts> requires std::is_aggregate_v<T>


### PR DESCRIPTION
This change is to make `template <reflect::fixed_string> ...` NTTP using CTAD more readable in compilation errors.

Readability of fixed_string before change:
![Readability of fixed_string before change](https://github.com/boost-ext/reflect/assets/1301304/2a9c10da-cbba-4035-a3e8-bb992c6ad16c)
```
reflect::fixed_string<char, 5UL - 1>{{{116, 101, 115, 116}}}
```
---
Readability of fixed_string after change:
![Readability of fixed_string after change](https://github.com/boost-ext/reflect/assets/1301304/9900044b-5b9b-4614-b5bf-cba7fe8c107a)
```
reflect::fixed_string<char, 4UL>{"test"}
```