### PR TITLE
:rotating_light: [diagnosis] Force string literal to display in GCC

### DIFF
--- a/reflect
+++ b/reflect
@@ -474,11 +474,14 @@ template<class T, fixed_string Name>
   }
 }
 
-template <auto Message>
-concept diagnosis = Message == std::string_view{};
+template<auto Message>
+struct print { static constexpr auto value = false; };
 
-template <class T, auto Name>
-concept member_name_diagnosis = diagnosis<diagnose_member_name<T, Name>()>;
+template<class TMessage>
+concept diagnosis = TMessage::value;
+
+template<class T, auto Name>
+concept member_name_diagnosis = diagnosis<print<diagnose_member_name<T, Name>()>>;
 } // namespace detail
 
 template<class T, fixed_string Name>


### PR DESCRIPTION
Before this change, only Clang displayed the diagnosis string literal while GCC did not expand the string literal in the compiler error.

## GCC 15.0.0

Before:
```
[build] /home/patrick/projects/reflect/reflect:478:9:   required for the satisfaction of ‘diagnosis<diagnose_member_name<T, Name>()>’ [with T = ._anon_95::operator()::foo; Name = reflect::v1_1_1::fixed_string<char, 3>{"baz"}]
[build] /home/patrick/projects/reflect/reflect:481:9:   required for the satisfaction of ‘member_name_diagnosis<typename std::remove_cvref<_Tp>::type, Name>’ [with T = ._anon_95::operator()::foo; Name = reflect::v1_1_1::fixed_string<char, 3>{"baz"}]
[build] /home/patrick/projects/reflect/reflect:478:29: note: the expression ‘Message == std::string_view({}) [with Message = diagnose_member_name()()]’ evaluated to ‘false’
[build]   478 | concept diagnosis = Message == std::string_view{};
[build]       |                     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
```
After:
```
[build] /home/patrick/projects/reflect/reflect:481:9:   required for the satisfaction of ‘diagnosis<reflect::v1_1_1::detail::print<diagnose_member_name<T, Name>()> >’ [with T = ._anon_95::operator()::foo; Name = reflect::v1_1_1::fixed_string<char, 3>{"baz"}]
[build] /home/patrick/projects/reflect/reflect:484:9:   required for the satisfaction of ‘member_name_diagnosis<typename std::remove_cvref<_Tp>::type, Name>’ [with T = ._anon_95::operator()::foo; Name = reflect::v1_1_1::fixed_string<char, 3>{"baz"}]
[build] /home/patrick/projects/reflect/reflect:481:31: note: the expression ‘TMessage::value [with TMessage = reflect::v1_1_1::detail::print<reflect::v1_1_1::fixed_string<char, 57>{"`foo` has no data member named `baz`. Did you mean `bar`?"}>]’ evaluated to ‘false’
[build]   481 | concept diagnosis = TMessage::value;
[build]       |                               ^~~~~
```

## Clang 18.1.8

Before:
```
[build] /home/patrick/projects/reflect/reflect:481:33: note: because diagnose_member_name<foo, fixed_string<char, 3UL>{"baz"}>() does not satisfy 'diagnosis'
[build]   481 | concept member_name_diagnosis = diagnosis<diagnose_member_name<T, Name>()>;
[build]       |                                 ^
[build] /home/patrick/projects/reflect/reflect:478:21: note: because 'fixed_string<char, 57UL>{"`foo` has no data member named `baz`. Did you mean `bar`?"} == std::string_view{}' evaluated to false
[build]   478 | concept diagnosis = Message == std::string_view{};
[build]       |                     ^
```
After:
```
[build] /home/patrick/projects/reflect/reflect:484:33: note: because 'print<diagnose_member_name<foo, fixed_string<char, 3UL>{"baz"}>()>' does not satisfy 'diagnosis'
[build]   484 | concept member_name_diagnosis = diagnosis<print<diagnose_member_name<T, Name>()>>;
[build]       |                                 ^
[build] /home/patrick/projects/reflect/reflect:481:21: note: because 'print<fixed_string<char, 57UL>{"`foo` has no data member named `baz`. Did you mean `bar`?"}>::value' evaluated to false
[build]   481 | concept diagnosis = TMessage::value;
[build]       |                     ^
```
